### PR TITLE
Added option `useNullForUnknownEnumValue`. When false the generated c…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,9 +10,9 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.swagger.codegen.v3</groupId>
+    <groupId>com.observepoint.swagger.codegen.v3</groupId>
     <artifactId>swagger-codegen-generators</artifactId>
-    <version>1.0.14</version>
+    <version>1.0.15</version>
     <packaging>jar</packaging>
 
     <build>
@@ -265,5 +265,31 @@
         <reflections-version>0.9.11</reflections-version>
 
     </properties>
+
+    <profiles>
+        <profile>
+            <id>observepoint-publish</id>
+            <repositories>
+                <repository>
+                    <id>observepoint-nexus-snapshots</id>
+                    <url>https://nexus.observepoint.com/repository/snapshots</url>
+                </repository>
+                <repository>
+                    <id>observepoint-nexus-releases</id>
+                    <url>https://nexus.observepoint.com/repository/releases</url>
+                </repository>
+            </repositories>
+            <distributionManagement>
+                <snapshotRepository>
+                    <id>observepoint-nexus-snapshots</id>
+                    <url>https://nexus.observepoint.com/repository/snapshots</url>
+                </snapshotRepository>
+                <repository>
+                    <id>observepoint-nexus-releases</id>
+                    <url>https://nexus.observepoint.com/repository/releases</url>
+                </repository>
+            </distributionManagement>
+        </profile>
+    </profiles>
 
 </project>

--- a/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegen.java
@@ -50,6 +50,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
     public static final String JAVA8_MODE = "java8";
     public static final String WITH_XML = "withXml";
     public static final String SUPPORT_JAVA6 = "supportJava6";
+    public static final String USE_NULL_FOR_UNKNOWN_ENUM_VALUE = "useNullForUnknownEnumValue";
 
     protected String dateLibrary = "threetenbp";
     protected boolean java8Mode = false;
@@ -81,6 +82,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
     protected String apiDocPath = "docs/";
     protected String modelDocPath = "docs/";
     protected boolean supportJava6= false;
+    protected boolean useNullForUnknownEnumValue = true;
 
     public AbstractJavaCodegen() {
         super();
@@ -202,6 +204,11 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
             this.setSupportJava6(Boolean.valueOf(additionalProperties.get(SUPPORT_JAVA6).toString()));
         }
         additionalProperties.put(SUPPORT_JAVA6, supportJava6);
+
+        if (additionalProperties.containsKey(USE_NULL_FOR_UNKNOWN_ENUM_VALUE)) {
+            this.setUseNullForUnknownEnumValue(Boolean.valueOf(additionalProperties.get(USE_NULL_FOR_UNKNOWN_ENUM_VALUE).toString()));
+        }
+        additionalProperties.put(USE_NULL_FOR_UNKNOWN_ENUM_VALUE, useNullForUnknownEnumValue);
 
         if (additionalProperties.containsKey(CodegenConstants.GROUP_ID)) {
             this.setGroupId((String) additionalProperties.get(CodegenConstants.GROUP_ID));
@@ -442,6 +449,8 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
         } else if (dateLibrary.equals("legacy")) {
             additionalProperties.put("legacyDates", true);
         }
+
+
     }
 
     private void sanitizeConfig() {
@@ -1355,6 +1364,10 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
 
     public void setJava8Mode(boolean enabled) {
         this.java8Mode = enabled;
+    }
+
+    public void setUseNullForUnknownEnumValue(boolean useNullForUnknownEnumValue) {
+        this.useNullForUnknownEnumValue = useNullForUnknownEnumValue;
     }
 
     @Override

--- a/src/main/resources/handlebars/Java/modelEnum.mustache
+++ b/src/main/resources/handlebars/Java/modelEnum.mustache
@@ -50,7 +50,7 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
         return b;
       }
     }
-    return null;
+    {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unknown enum value '" + text + "'");{{/useNullForUnknownEnumValue}}
   }
 {{#if gson}}
 

--- a/src/main/resources/handlebars/Java/modelInnerEnum.mustache
+++ b/src/main/resources/handlebars/Java/modelInnerEnum.mustache
@@ -34,7 +34,7 @@
           return b;
         }
       }
-      return null;
+      {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unknown enum value '" + text + "'");{{/useNullForUnknownEnumValue}}
     }
     {{#gson}}
     public static class Adapter extends TypeAdapter<{{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}> {

--- a/src/main/resources/handlebars/JavaInflector/enumClass.mustache
+++ b/src/main/resources/handlebars/JavaInflector/enumClass.mustache
@@ -39,6 +39,6 @@
           return b;
         }
       }
-      return null;
+      {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unknown enum value '" + text + "'");{{/useNullForUnknownEnumValue}}
     }
   }

--- a/src/main/resources/handlebars/JavaInflector/enumOuterClass.mustache
+++ b/src/main/resources/handlebars/JavaInflector/enumOuterClass.mustache
@@ -42,6 +42,6 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
         return b;
       }
     }
-    return null;
+    {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unknown enum value '" + text + "'");{{/useNullForUnknownEnumValue}}
   }
 }

--- a/src/main/resources/handlebars/JavaJaxRS/cxf-cdi/enumClass.mustache
+++ b/src/main/resources/handlebars/JavaJaxRS/cxf-cdi/enumClass.mustache
@@ -28,6 +28,6 @@ public enum {{datatypeWithEnum}} {
                 return b;
             }
         }
-        return null;
+        {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unknown enum value '" + text + "'");{{/useNullForUnknownEnumValue}}
     }
 }

--- a/src/main/resources/handlebars/JavaJaxRS/cxf/enumClass.mustache
+++ b/src/main/resources/handlebars/JavaJaxRS/cxf/enumClass.mustache
@@ -28,6 +28,6 @@ public enum {{datatypeWithEnum}} {
                 return b;
             }
         }
-        return null;
+        {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unknown enum value '" + text + "'");{{/useNullForUnknownEnumValue}}
     }
 }

--- a/src/main/resources/handlebars/JavaJaxRS/cxf/enumOuterClass.mustache
+++ b/src/main/resources/handlebars/JavaJaxRS/cxf/enumOuterClass.mustache
@@ -57,7 +57,7 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
         return b;
       }
     }
-    return null;
+    {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unknown enum value '" + text + "'");{{/useNullForUnknownEnumValue}}
   }
   
 }

--- a/src/main/resources/handlebars/JavaJaxRS/cxf/modelInnerEnum.mustache
+++ b/src/main/resources/handlebars/JavaJaxRS/cxf/modelInnerEnum.mustache
@@ -26,6 +26,6 @@
           return b;
         }
       }
-      return null;
+      {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unknown enum value '" + text + "'");{{/useNullForUnknownEnumValue}}
     }
   }

--- a/src/main/resources/handlebars/JavaJaxRS/enumClass.mustache
+++ b/src/main/resources/handlebars/JavaJaxRS/enumClass.mustache
@@ -39,6 +39,6 @@
           return b;
         }
       }
-      return null;
+      {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unknown enum value '" + text + "'");{{/useNullForUnknownEnumValue}}
     }
   }

--- a/src/main/resources/handlebars/JavaJaxRS/enumOuterClass.mustache
+++ b/src/main/resources/handlebars/JavaJaxRS/enumOuterClass.mustache
@@ -37,6 +37,6 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
         return b;
       }
     }
-    return null;
+    {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unknown enum value '" + text + "'");{{/useNullForUnknownEnumValue}}
   }
 }

--- a/src/main/resources/handlebars/JavaJaxRS/modelEnum.mustache
+++ b/src/main/resources/handlebars/JavaJaxRS/modelEnum.mustache
@@ -37,7 +37,7 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
         return b;
       }
     }
-    return null;
+    {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unknown enum value '" + text + "'");{{/useNullForUnknownEnumValue}}
   }
 {{/jackson}}
 }

--- a/src/main/resources/handlebars/JavaJaxRS/spec/enumClass.mustache
+++ b/src/main/resources/handlebars/JavaJaxRS/spec/enumClass.mustache
@@ -28,6 +28,6 @@ public enum {{datatypeWithEnum}} {
                 return b;
             }
         }
-        return null;
+        {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unknown enum value '" + text + "'");{{/useNullForUnknownEnumValue}}
     }
 }

--- a/src/main/resources/handlebars/JavaJaxRS/spec/enumOuterClass.mustache
+++ b/src/main/resources/handlebars/JavaJaxRS/spec/enumOuterClass.mustache
@@ -38,6 +38,6 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
         return b;
       }
     }
-    return null;
+    {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unknown enum value '" + text + "'");{{/useNullForUnknownEnumValue}}
   }
 }

--- a/src/main/resources/handlebars/JavaMicronaut/enumClass.mustache
+++ b/src/main/resources/handlebars/JavaMicronaut/enumClass.mustache
@@ -39,6 +39,6 @@
           return b;
         }
       }
-      return null;
+      {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unknown enum value '" + text + "'");{{/useNullForUnknownEnumValue}}
     }
   }

--- a/src/main/resources/handlebars/JavaMicronaut/enumOuterClass.mustache
+++ b/src/main/resources/handlebars/JavaMicronaut/enumOuterClass.mustache
@@ -37,6 +37,6 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
         return b;
       }
     }
-    return null;
+    {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unknown enum value '" + text + "'");{{/useNullForUnknownEnumValue}}
   }
 }

--- a/src/main/resources/handlebars/JavaSpring/enumClass.mustache
+++ b/src/main/resources/handlebars/JavaSpring/enumClass.mustache
@@ -39,6 +39,6 @@
           return b;
         }
       }
-      return null;
+      {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unknown enum value '" + text + "'");{{/useNullForUnknownEnumValue}}
     }
   }

--- a/src/main/resources/handlebars/JavaSpring/enumOuterClass.mustache
+++ b/src/main/resources/handlebars/JavaSpring/enumOuterClass.mustache
@@ -37,6 +37,6 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
         return b;
       }
     }
-    return null;
+    {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unknown enum value '" + text + "'");{{/useNullForUnknownEnumValue}}
   }
 }

--- a/src/main/resources/mustache/Java/modelEnum.mustache
+++ b/src/main/resources/mustache/Java/modelEnum.mustache
@@ -48,7 +48,7 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
         return b;
       }
     }
-    return null;
+    {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unknown enum value '" + text + "'");{{/useNullForUnknownEnumValue}}
   }
 {{#gson}}
 

--- a/src/main/resources/mustache/Java/modelInnerEnum.mustache
+++ b/src/main/resources/mustache/Java/modelInnerEnum.mustache
@@ -39,7 +39,7 @@
           return b;
         }
       }
-      return null;
+      {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unknown enum value '" + text + "'");{{/useNullForUnknownEnumValue}}
     }
 {{#gson}}
 

--- a/src/main/resources/mustache/JavaInflector/enumClass.mustache
+++ b/src/main/resources/mustache/JavaInflector/enumClass.mustache
@@ -39,6 +39,6 @@
           return b;
         }
       }
-      return null;
+      {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unknown enum value '" + text + "'");{{/useNullForUnknownEnumValue}}
     }
   }

--- a/src/main/resources/mustache/JavaInflector/enumOuterClass.mustache
+++ b/src/main/resources/mustache/JavaInflector/enumOuterClass.mustache
@@ -37,6 +37,6 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
         return b;
       }
     }
-    return null;
+    {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unknown enum value '" + text + "'");{{/useNullForUnknownEnumValue}}
   }
 }

--- a/src/main/resources/mustache/JavaJaxRS/cxf-cdi/enumClass.mustache
+++ b/src/main/resources/mustache/JavaJaxRS/cxf-cdi/enumClass.mustache
@@ -28,6 +28,6 @@ public enum {{datatypeWithEnum}} {
                 return b;
             }
         }
-        return null;
+        {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unknown enum value '" + text + "'");{{/useNullForUnknownEnumValue}}
     }
 }

--- a/src/main/resources/mustache/JavaJaxRS/cxf/enumClass.mustache
+++ b/src/main/resources/mustache/JavaJaxRS/cxf/enumClass.mustache
@@ -28,6 +28,6 @@ public enum {{datatypeWithEnum}} {
                 return b;
             }
         }
-        return null;
+        {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unknown enum value '" + text + "'");{{/useNullForUnknownEnumValue}}
     }
 }

--- a/src/main/resources/mustache/JavaJaxRS/cxf/enumOuterClass.mustache
+++ b/src/main/resources/mustache/JavaJaxRS/cxf/enumOuterClass.mustache
@@ -42,7 +42,7 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
         return b;
       }
     }
-    return null;
+    {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unknown enum value '" + text + "'");{{/useNullForUnknownEnumValue}}
   }
   
 }

--- a/src/main/resources/mustache/JavaJaxRS/enumClass.mustache
+++ b/src/main/resources/mustache/JavaJaxRS/enumClass.mustache
@@ -39,6 +39,6 @@
           return b;
         }
       }
-      return null;
+      {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unknown enum value '" + text + "'");{{/useNullForUnknownEnumValue}}
     }
   }

--- a/src/main/resources/mustache/JavaJaxRS/enumOuterClass.mustache
+++ b/src/main/resources/mustache/JavaJaxRS/enumOuterClass.mustache
@@ -37,6 +37,6 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
         return b;
       }
     }
-    return null;
+    {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unknown enum value '" + text + "'");{{/useNullForUnknownEnumValue}}
   }
 }

--- a/src/main/resources/mustache/JavaJaxRS/modelEnum.mustache
+++ b/src/main/resources/mustache/JavaJaxRS/modelEnum.mustache
@@ -37,7 +37,7 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
         return b;
       }
     }
-    return null;
+    {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unknown enum value '" + text + "'");{{/useNullForUnknownEnumValue}}
   }
 {{/jackson}}
 }

--- a/src/main/resources/mustache/JavaJaxRS/spec/enumClass.mustache
+++ b/src/main/resources/mustache/JavaJaxRS/spec/enumClass.mustache
@@ -28,6 +28,6 @@ public enum {{datatypeWithEnum}} {
                 return b;
             }
         }
-        return null;
+        {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unknown enum value '" + text + "'");{{/useNullForUnknownEnumValue}}
     }
 }

--- a/src/main/resources/mustache/JavaJaxRS/spec/enumOuterClass.mustache
+++ b/src/main/resources/mustache/JavaJaxRS/spec/enumOuterClass.mustache
@@ -38,6 +38,6 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
         return b;
       }
     }
-    return null;
+    {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unknown enum value '" + text + "'");{{/useNullForUnknownEnumValue}}
   }
 }


### PR DESCRIPTION
Added option `useNullForUnknownEnumValue`.

- When `false` the generated code throws an exception when the value is unknown (not present in the enum).
- When `true` (original behavior): unknown values are mapped to `null`.

Port of https://github.com/OpenAPITools/openapi-generator/pull/633